### PR TITLE
ci: `--rm-dist` is deprecated

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,6 @@ jobs:
           go-version-file: go.mod
       - uses: goreleaser/goreleaser-action@v5
         with:
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
https://goreleaser.com/deprecations/#-rm-dist